### PR TITLE
feat(mountebank): allow existing Mountebank

### DIFF
--- a/mountepy/__init__.py
+++ b/mountepy/__init__.py
@@ -5,6 +5,6 @@ Spawning and cleaning after given HTTP service processes and Mountebank.
 import pkg_resources
 
 from mountepy.http_service import HttpService, ServiceGroup, wait_for_port
-from mountepy.mountebank import Mountebank, HttpStub
+from mountepy.mountebank import Mountebank, ExistingMountebank, HttpStub
 
 __version__ = pkg_resources.get_distribution(__name__).version # pylint: disable=no-member

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os.path
 from setuptools import setup
 
 project_name = 'mountepy'
-version = '0.3.3'
+version = '0.4.0'
 
 setup_dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(setup_dir, 'requirements.txt')) as req_file:


### PR DESCRIPTION
Add `ExistingMountebank`: like `Mountebank`, but uses an existing
mountebank process, managed outside of `mountepy`.

Usage:
```python
with ExistingMountebank(host, port) as mb:
    ...
```